### PR TITLE
Using default cassandra configuration directory

### DIFF
--- a/src/universal/bin/conductr-cassandra.in.sh
+++ b/src/universal/bin/conductr-cassandra.in.sh
@@ -14,13 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if [ "x$CASSANDRA_HOME" = "x" ]; then
-    CASSANDRA_HOME="`dirname "$0"`/.."
-fi
-
 # The directory where Cassandra's configs live (required)
 if [ "x$CASSANDRA_CONF" = "x" ]; then
-    CASSANDRA_CONF="$CASSANDRA_HOME/conf"
+    BUNDLE_DIR="$( cd $( dirname "${BASH_SOURCE[0]}" ) && pwd )"
+    CASSANDRA_CONF="$BUNDLE_DIR/conf"
+fi
+
+if [ "x$CASSANDRA_HOME" = "x" ]; then
+    CASSANDRA_HOME="`dirname "$0"`/.."
 fi
 
 # This can be the path to a jar file, or a directory containing the


### PR DESCRIPTION
Changes the `cassandra-cassandra.in.sh` file so that as the cassandra bundle configuration the default `BUNDLE_DIR/conf` is picked if the env `CASSANDRA_CONF` is not set by a custom bundle configuration.

This makes it possible to provide a custom bundle configuration that includes only a `bundle.conf`.