### PR TITLE
Support multiple bundle instances on a single host

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,15 @@ The bundle will form a cluster with the name associated with the bundle's `syste
 
 > Disclaimer: Cassandra is a very sophisticated database. Although ConductR makes it easy to launch and scale Cassandra, you should still [learn about Cassandra](http://www.tutorialspoint.com/cassandra/).
 
-### Cassandra nodes
+### Working directories
 
-The bundle will assume that the Cassandra directories reside outside of the bundle itself, depending on the OS:
+The bundle will assume that the Cassandra working directories reside outside of the bundle itself. The location of the Cassandra working directories are depending on:
 
-- Linux: `/var/lib`
-- macOS: `/usr/local/var/lib`
+- Operation system
+- Bundle name and Bundle compatibility version
+- Cassandra node address
+
+On Linux, the base directory is `/var/lib`. On macOS, the base directory is `/usr/local/var/lib`.
 
 Cassandra's convention is to use `cassandra` as the sub directory e.g. `/var/lib/cassandra`. This bundle will substitute the `$BUNDLE_NAME-v$BUNDLE_COMPATIBILITY_VERSION` environment vars in place of `cassandra` e.g. `/var/lib/cassandra-v3` (the compatibility version has been set to 3 by default in order to signify Cassandra v.3).
 
@@ -32,6 +35,16 @@ sudo chown conductr /var/lib/cassandra-v3
 ```
 
 Note when using the sandbox, the directories are created automatically.
+
+To support several Cassandra instances on a single host, each bundle instance will create a sub directory based on the node address, e.g.
+ 
+```
+/var/lib/cassandra/v3/192.168.10.1
+/var/lib/cassandra/v3/192.168.10.2
+/var/lib/cassandra/v3/192.168.10.3
+```
+
+### Roles
 
 The `cassandra` role is assigned to this bundle by default so make sure that the ConductR service on that node has that role. Note that on the sandbox, roles are disabled by default so you don't need to worry about it.
 

--- a/src/universal/bin/conductr-cassandra.in.sh
+++ b/src/universal/bin/conductr-cassandra.in.sh
@@ -98,13 +98,14 @@ then
 fi
 perl -i -pe 's/(- seeds:) "127.0.0.1"/\1 "'$CASSANDRA_SEEDS'"/' "$CASSANDRA_CONF/cassandra.yaml"
 
-VAR_LIB_DIR='\/var\/lib'
+VAR_LIB_DIR="\/var\/lib"
 UNAMESTR=`uname`
 if [ "$UNAMESTR" == "Darwin" ]; then
    VAR_LIB_DIR="\/usr\/local\/var\/lib"
 fi
-perl -i -pe 's/^# (hints_directory:) \/var\/lib\/cassandra\/hints/\1 '$VAR_LIB_DIR'\/'$BUNDLE_NAME-v$BUNDLE_COMPATIBILITY_VERSION'\/hints/' "$CASSANDRA_CONF/cassandra.yaml"
+CASSANDRA_BASE_DIR="$VAR_LIB_DIR\/$BUNDLE_NAME-v$BUNDLE_COMPATIBILITY_VERSION\/$CAS_STORAGE_BIND_IP"
+perl -i -pe 's/^# (hints_directory:) \/var\/lib\/cassandra\/hints/\1 '$CASSANDRA_BASE_DIR'\/hints/' "$CASSANDRA_CONF/cassandra.yaml"
 perl -i -pe 's/^# (data_file_directories:)/\1/' "$CASSANDRA_CONF/cassandra.yaml"
-perl -i -pe 's/^# (    -) \/var\/lib\/cassandra\/data/\1 '$VAR_LIB_DIR'\/'$BUNDLE_NAME-v$BUNDLE_COMPATIBILITY_VERSION'\/data/' "$CASSANDRA_CONF/cassandra.yaml"
-perl -i -pe 's/^# (commitlog_directory:) \/var\/lib\/cassandra\/commitlog/\1 '$VAR_LIB_DIR'\/'$BUNDLE_NAME-v$BUNDLE_COMPATIBILITY_VERSION'\/commitlog/' "$CASSANDRA_CONF/cassandra.yaml"
-perl -i -pe 's/^# (saved_caches_directory:) \/var\/lib\/cassandra\/saved_caches/\1 '$VAR_LIB_DIR'\/'$BUNDLE_NAME-v$BUNDLE_COMPATIBILITY_VERSION'\/saved_caches/' "$CASSANDRA_CONF/cassandra.yaml"
+perl -i -pe 's/^# (    -) \/var\/lib\/cassandra\/data/\1 '$CASSANDRA_BASE_DIR'\/data/' "$CASSANDRA_CONF/cassandra.yaml"
+perl -i -pe 's/^# (commitlog_directory:) \/var\/lib\/cassandra\/commitlog/\1 '$CASSANDRA_BASE_DIR'\/commitlog/' "$CASSANDRA_CONF/cassandra.yaml"
+perl -i -pe 's/^# (saved_caches_directory:) \/var\/lib\/cassandra\/saved_caches/\1 '$CASSANDRA_BASE_DIR'\/saved_caches/' "$CASSANDRA_CONF/cassandra.yaml"


### PR DESCRIPTION
Supporting multuple Cassandra bundle instances on a single host by namespacing the Cassandra working directories as `/var/lib/cassandra-v3/$CAS_STORAGE_BIND_IP`, e.g. /var/lib/cassandra-v3/192.168.10.1`.

This is all needed to support multiple instances on a single host. Followed this guide: http://www.datastax.com/dev/blog/running-multiple-datastax-enterprise-nodes-in-a-single-host

Tested with the sandbox and `activator-lagom-chirper-java`