### PR TITLE
Convert service URI to Request ACLs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ BundleKeys.diskSpace := 100.MB
 BundleKeys.roles := Set("cassandra")
 
 BundleKeys.endpoints := Map(
-  "cas_native" ->  Endpoint("tcp", services = Set(uri("tcp://:9042/cas_native"))),
+  "cas_native" ->  Endpoint("tcp", 0, serviceName = "cas_native", RequestAcl(Tcp(9042))),
   "cas_rpc" ->     Endpoint("tcp"),
   "cas_storage" -> Endpoint("tcp", 7000)
 )


### PR DESCRIPTION
This is to allow Cassandra bundle to work with ConductR 2.1 and 2.0.

By doing this we are dropping support for ConductR 1 with this bundle.